### PR TITLE
Add video player support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:configChanges="orientation|screenSize|screenLayout|smallestScreenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/org/rubyevents/app/MainApplication.kt
+++ b/app/src/main/java/org/rubyevents/app/MainApplication.kt
@@ -8,6 +8,7 @@ import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.config.PathConfiguration
 import dev.hotwire.navigation.config.registerBridgeComponents
 import org.rubyevents.app.hotwire.bridge.ButtonComponent
+import org.rubyevents.app.hotwire.CustomWebView
 
 class MainApplication : Application() {
     override fun onCreate() {
@@ -28,6 +29,11 @@ class MainApplication : Application() {
         Hotwire.registerBridgeComponents(
             BridgeComponentFactory("button", ::ButtonComponent)
         )
+
+        // Custom WebView
+        Hotwire.config.makeCustomWebView = { context ->
+            CustomWebView(context, null)
+        }
 
         // General configuration
         Hotwire.config.debugLoggingEnabled = BuildConfig.DEBUG

--- a/app/src/main/java/org/rubyevents/app/MainApplication.kt
+++ b/app/src/main/java/org/rubyevents/app/MainApplication.kt
@@ -6,8 +6,11 @@ import dev.hotwire.core.bridge.BridgeComponentFactory
 import dev.hotwire.core.bridge.KotlinXJsonConverter
 import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.config.PathConfiguration
+import dev.hotwire.navigation.config.defaultFragmentDestination
 import dev.hotwire.navigation.config.registerBridgeComponents
+import dev.hotwire.navigation.config.registerFragmentDestinations
 import org.rubyevents.app.hotwire.bridge.ButtonComponent
+import org.rubyevents.app.hotwire.fragments.WebFragment
 import org.rubyevents.app.hotwire.CustomWebView
 
 class MainApplication : Application() {
@@ -17,6 +20,14 @@ class MainApplication : Application() {
     }
 
     private fun configureApp() {
+        // Default fragment
+        Hotwire.defaultFragmentDestination = WebFragment::class
+
+        // All available fragments
+        Hotwire.registerFragmentDestinations(
+            WebFragment::class
+        )
+
         // PathConfiguration
         Hotwire.loadPathConfiguration(
             context = this,

--- a/app/src/main/java/org/rubyevents/app/hotwire/CustomChromeClient.kt
+++ b/app/src/main/java/org/rubyevents/app/hotwire/CustomChromeClient.kt
@@ -1,0 +1,88 @@
+package org.rubyevents.app.hotwire
+
+import android.content.pm.ActivityInfo
+import android.os.Build
+import android.view.ViewGroup
+import android.view.View
+import android.view.WindowInsets
+import android.view.WindowInsetsController
+import android.widget.FrameLayout
+import androidx.fragment.app.FragmentActivity
+import dev.hotwire.core.turbo.session.Session
+import dev.hotwire.core.turbo.webview.HotwireWebChromeClient
+import java.lang.ref.WeakReference
+
+class CustomChromeClient(session: Session, activity: FragmentActivity?) : HotwireWebChromeClient(session) {
+    private var customView: View? = null
+    private var customViewCallback: CustomViewCallback? = null
+    private var originalSystemUiVisibility = 0
+
+    private val activityReference: WeakReference<FragmentActivity> = WeakReference(activity)
+
+    // Override onShowCustomView to handle fullscreen video playback
+    override fun onShowCustomView(view: View?, callback: CustomViewCallback?) {
+        val activity = activityReference.get() ?: run {
+            callback?.onCustomViewHidden()
+            return
+        }
+
+        if (view == null || customView != null) {
+            callback?.onCustomViewHidden()
+            return
+        }
+
+        customView = view
+        customViewCallback = callback
+        showCustomViewInActivity(view, activity)
+    }
+
+    // Override onHideCustomView to handle exiting the fullscreen video playback
+    override fun onHideCustomView() {
+        val activity = activityReference.get() ?: return
+
+        hideCustomViewInActivity(activity)
+        customViewCallback?.onCustomViewHidden()
+        customViewCallback = null
+        resetOrientationAndVisibility(activity)
+    }
+
+    private fun showCustomViewInActivity(view: View, activity: FragmentActivity) {
+        val decorView = activity.window.decorView as FrameLayout
+        originalSystemUiVisibility = decorView.systemUiVisibility
+
+        decorView.addView(view, FrameLayout.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT
+        ))
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.window.insetsController?.apply {
+                hide(android.view.WindowInsets.Type.systemBars())
+                systemBarsBehavior = WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+            }
+        } else {
+            decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_FULLSCREEN
+                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+        }
+
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+    }
+
+    private fun hideCustomViewInActivity(activity: FragmentActivity) {
+        val decorView = activity.window.decorView as FrameLayout
+        decorView.removeView(customView)
+        customView = null
+    }
+
+    private fun resetOrientationAndVisibility(activity: FragmentActivity) {
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            activity.window.insetsController?.show(WindowInsets.Type.systemBars())
+        } else {
+            val decorView = activity.window.decorView as FrameLayout
+            decorView.systemUiVisibility = originalSystemUiVisibility
+        }
+    }
+}

--- a/app/src/main/java/org/rubyevents/app/hotwire/CustomWebView.kt
+++ b/app/src/main/java/org/rubyevents/app/hotwire/CustomWebView.kt
@@ -1,0 +1,16 @@
+package org.rubyevents.app.hotwire
+
+import android.content.Context
+import android.util.AttributeSet
+import dev.hotwire.core.turbo.webview.HotwireWebView
+
+class CustomWebView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : HotwireWebView(context, attrs) {
+    init {
+        // Disable media playback requiring user gesture
+        // Without this, the videos on the web app won't play
+        settings.mediaPlaybackRequiresUserGesture = false
+    }
+}

--- a/app/src/main/java/org/rubyevents/app/hotwire/fragments/WebFragment.kt
+++ b/app/src/main/java/org/rubyevents/app/hotwire/fragments/WebFragment.kt
@@ -1,0 +1,13 @@
+package org.rubyevents.app.hotwire.fragments
+
+import org.rubyevents.app.hotwire.CustomChromeClient
+import dev.hotwire.core.turbo.webview.HotwireWebChromeClient
+import dev.hotwire.navigation.destinations.HotwireDestinationDeepLink
+import dev.hotwire.navigation.fragments.HotwireWebFragment
+
+@HotwireDestinationDeepLink(uri = "hotwire://fragment/web")
+open class WebFragment : HotwireWebFragment() {
+    override fun createWebChromeClient(): HotwireWebChromeClient {
+        return CustomChromeClient(navigator.session, activity)
+    }
+}


### PR DESCRIPTION
Before this PR, videos were not playable in the app.
To make them playable, we need to set the WebView setting `mediaPlaybackRequiresUserGesture` to false.

Additionally, we need to provide some handling for supporting fullscreen. Otherwise, you'll encounter the JavaScript error: "Fullscreen is not supported."
This occurs because the app technically leaves the WebView and switches to a custom Android view when entering fullscreen. 
Since this behavior isn't supported by default, this PR introduces a `CustomChromeClient`, subclassed from `HotwireWebChromeClient`, to handle these events.